### PR TITLE
Potential fix for code scanning alert no. 18: Uncontrolled data used in path expression

### DIFF
--- a/app.py
+++ b/app.py
@@ -608,7 +608,11 @@ def resize_batch_options(filenames=None):
     first_file_path = None
 
     for filename in filenames:
-        filepath = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+        # Normalize the filename and ensure it is within the UPLOAD_FOLDER directory
+        filepath = os.path.normpath(os.path.join(app.config['UPLOAD_FOLDER'], filename))
+        if not filepath.startswith(os.path.abspath(app.config['UPLOAD_FOLDER'])):
+            app.logger.error(f"Invalid file path: {filepath}")
+            continue
         if not os.path.exists(filepath):
             continue
             


### PR DESCRIPTION
Potential fix for [https://github.com/tiritibambix/ImaGUIck/security/code-scanning/18](https://github.com/tiritibambix/ImaGUIck/security/code-scanning/18)

To fix the problem, we need to ensure that the `filename` is validated and sanitized before being used to construct the `filepath`. The best way to do this is to normalize the path and ensure it is within a safe directory. We can use `os.path.normpath` to normalize the path and then check if the resulting path starts with the intended upload directory.

1. Normalize the `filename` using `os.path.normpath`.
2. Ensure the normalized path starts with the `UPLOAD_FOLDER` directory.
3. If the path is not valid, handle the error appropriately (e.g., skip the file or return an error message).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
