### PR TITLE
Potential fix for code scanning alert no. 17: Uncontrolled data used in path expression

### DIFF
--- a/app.py
+++ b/app.py
@@ -464,7 +464,11 @@ def upload_url():
 @app.route('/resize_options/<filename>')
 def resize_options(filename):
     """Resize options page for a single image."""
-    filepath = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+    filename = secure_filename(filename)
+    filepath = os.path.normpath(os.path.join(app.config['UPLOAD_FOLDER'], filename))
+    if not filepath.startswith(app.config['UPLOAD_FOLDER']):
+        flash('Invalid file path')
+        return redirect(url_for('index'))
     dimensions = get_image_dimensions(filepath)
     if not dimensions:
         return redirect(url_for('index'))


### PR DESCRIPTION
Potential fix for [https://github.com/tiritibambix/ImaGUIck/security/code-scanning/17](https://github.com/tiritibambix/ImaGUIck/security/code-scanning/17)

To fix the problem, we need to ensure that the `filename` provided by the user is safe and does not allow path traversal. We can achieve this by normalizing the path and ensuring it remains within the intended directory. Additionally, we can use the `secure_filename` function from `werkzeug.utils` to sanitize the filename.

1. Normalize the `filepath` using `os.path.normpath`.
2. Ensure the normalized path starts with the `UPLOAD_FOLDER` to prevent directory traversal.
3. Use `secure_filename` to sanitize the `filename`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
