### PR TITLE
Potential fix for code scanning alert no. 86: Uncontrolled command line

### DIFF
--- a/app.py
+++ b/app.py
@@ -334,6 +334,8 @@ def build_imagemagick_command(filepath, output_path, width, height, percentage, 
     """Build ImageMagick command for resizing and formatting."""
     if not secure_path(filepath) or not secure_path(output_path):
         return None
+    filepath = secure_filename(filepath)
+    output_path = secure_filename(output_path)
 
     if filepath.lower().endswith('.jxl'):
         # Utiliser djxl pour décoder JXL
@@ -502,6 +504,7 @@ def resize_options(filename):
 @app.route('/resize/<filename>', methods=['POST'])
 def resize_image(filename):
     """Handle resizing or format conversion for a single image."""
+    filename = secure_filename(filename)
     try:
         # Récupérer les paramètres
         width = request.form.get('width', '')


### PR DESCRIPTION
Potential fix for [https://github.com/tiritibambix/ImaGUIck/security/code-scanning/86](https://github.com/tiritibambix/ImaGUIck/security/code-scanning/86)

To fix the problem, we need to ensure that the `filename` parameter is properly validated and sanitized before being used in any command execution. This can be achieved by using a predefined allowlist of acceptable filenames or by ensuring that the `filename` does not contain any malicious characters.

The best way to fix the problem without changing existing functionality is to:
1. Validate the `filename` to ensure it only contains safe characters.
2. Use the `secure_filename` function from `werkzeug.utils` to sanitize the `filename`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
