### PR TITLE
Potential fix for code scanning alert no. 86: Uncontrolled command line

### DIFF
--- a/app.py
+++ b/app.py
@@ -332,6 +332,8 @@ def flash_error(message):
 def build_imagemagick_command(filepath, output_path, width, height, percentage, quality, keep_ratio,
                          auto_level=False, auto_gamma=False, use_1080p=False, use_sharpen=False, sharpen_level='standard'):
     """Build ImageMagick command for resizing and formatting."""
+    filepath = secure_filename(filepath)
+    output_path = secure_filename(output_path)
     if not secure_path(filepath) or not secure_path(output_path):
         return None
 
@@ -502,6 +504,7 @@ def resize_options(filename):
 @app.route('/resize/<filename>', methods=['POST'])
 def resize_image(filename):
     """Handle resizing or format conversion for a single image."""
+    filename = secure_filename(filename)
     try:
         # Récupérer les paramètres
         width = request.form.get('width', '')


### PR DESCRIPTION
Potential fix for [https://github.com/tiritibambix/ImaGUIck/security/code-scanning/86](https://github.com/tiritibambix/ImaGUIck/security/code-scanning/86)

To fix the problem, we need to ensure that the `filename` parameter is properly sanitized before being used in a command line. One effective way to do this is to use the `secure_filename` function from the `werkzeug.utils` module, which ensures that the filename is safe to use. Additionally, we should avoid directly using user input in command lines and instead use predefined or validated values.

1. Modify the `resize_image` function to use `secure_filename` for the `filename` parameter.
2. Update the `build_imagemagick_command` function to use the sanitized `filename`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
