### PR TITLE
Potential fix for code scanning alert no. 86: Uncontrolled command line

### DIFF
--- a/app.py
+++ b/app.py
@@ -333,11 +333,12 @@ def build_imagemagick_command(filepath, output_path, width, height, percentage, 
                          auto_level=False, auto_gamma=False, use_1080p=False, use_1920p=False, use_sharpen=False, sharpen_level='standard'):
     """Build ImageMagick command for resizing and formatting."""
     if not secure_path(filepath) or not secure_path(output_path):
+        app.logger.error("Insecure file path detected")
         return None
 
     if filepath.lower().endswith('.jxl'):
         # Utiliser djxl pour décoder JXL
-        cmd = ['djxl', filepath, '-o', '/tmp/decoded_image.png']
+        cmd = ['djxl', os.path.abspath(filepath), '-o', '/tmp/decoded_image.png']
         subprocess.run(cmd, check=True)
         filepath = '/tmp/decoded_image.png'
     command = ['magick', filepath]
@@ -507,6 +508,13 @@ def resize_options(filename):
 @app.route('/resize/<filename>', methods=['POST'])
 def resize_image(filename):
     """Handle resizing or format conversion for a single image."""
+    # Validate filename to ensure it contains only safe characters
+    if not re.match(r'^[\w\-.]+$', filename):
+        flash('Invalid filename')
+        return render_template('result.html', 
+                             success=False, 
+                             title='Error',
+                             return_url=url_for('index'))
     try:
         # Récupérer les paramètres
         width = request.form.get('width', '')


### PR DESCRIPTION
Potential fix for [https://github.com/Tiritibambix/ImaGUIck/security/code-scanning/86](https://github.com/Tiritibambix/ImaGUIck/security/code-scanning/86)

To fix the issue, we need to ensure that the `filename` parameter is validated and sanitized before it is used to construct the `cmd` list. This can be achieved by:
1. Using a strict allowlist of acceptable filenames or file extensions.
2. Ensuring that the `secure_path` function is robust and explicitly checks for directory traversal attempts and other malicious patterns.
3. Avoiding direct use of user-provided input in subprocess calls. Instead, use hardcoded paths or validated inputs.

In this case, we will:
- Add a validation step to ensure that `filename` only contains safe characters (e.g., alphanumeric characters, underscores, and hyphens).
- Ensure that `secure_path` is used effectively to validate the `filepath`.
- Refactor the `cmd` construction to use only validated inputs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
